### PR TITLE
fix(stories): prevent ValueError for some stories with invalid data length

### DIFF
--- a/pkg/api/stories.py
+++ b/pkg/api/stories.py
@@ -508,10 +508,13 @@ def xxtea_decipher(buffer, key, offset, dec_len):
         dec_len = len(buffer) - offset
     # if something to be done
     if offset < len(buffer) and offset + dec_len <= len(buffer):
-        plain = xxtea.decrypt(buffer[offset:dec_len], key, padding=False, rounds=lunii_tea_rounds(buffer[offset:dec_len]))
-        ba_buffer = bytearray(buffer)
-        ba_buffer[offset:dec_len] = plain
-        buffer = bytes(ba_buffer)
+        chunk = buffer[offset:dec_len]
+        # Safety check: Data length must be a multiple of 4 bytes and must not be less than 8 bytes
+        if len(chunk) >= 8 and len(chunk) % 4 == 0:
+            plain = xxtea.decrypt(chunk, key, padding=False, rounds=lunii_tea_rounds(chunk))
+            ba_buffer = bytearray(buffer)
+            ba_buffer[offset:dec_len] = plain
+            buffer = bytes(ba_buffer)
     return buffer
 
 def xxtea_cipher(buffer, key, offset, enc_len):
@@ -523,10 +526,13 @@ def xxtea_cipher(buffer, key, offset, enc_len):
         enc_len = len(buffer) - offset
     # if something to be done
     if offset < len(buffer) and offset + enc_len <= len(buffer):
-        ciphered = xxtea.encrypt(buffer[offset:enc_len], key, padding=False, rounds=lunii_tea_rounds(buffer[offset:enc_len]))
-        ba_buffer = bytearray(buffer)
-        ba_buffer[offset:enc_len] = ciphered
-        buffer = bytes(ba_buffer)
+        chunk = buffer[offset:enc_len]
+        # Safety check: Data length must be a multiple of 4 bytes and must not be less than 8 bytes
+        if len(chunk) >= 8 and len(chunk) % 4 == 0:
+            ciphered = xxtea.encrypt(chunk, key, padding=False, rounds=lunii_tea_rounds(chunk))
+            ba_buffer = bytearray(buffer)
+            ba_buffer[offset:enc_len] = ciphered
+            buffer = bytes(ba_buffer)
     return buffer
 
 def aes_decipher(buffer, key, iv, offset, dec_len):


### PR DESCRIPTION
## Description

similar to #24 

The application crashes with `ValueError: Data length must be a multiple of 4 bytes and must not be less than 8 bytes` when importing certain Lunii V2 zip stories. 

Example: 5+ Suzanne et Gaston découvrent la Préhistoire.zip

The `xxtea` library requires that the data to be decrypted is at least 8 bytes long and is a multiple of 4 bytes. However, in some instances, data chunks that do not meet these constraints were passed to the function, causing the error.

## Log
```
[INFO] 🛑 Critical error : Data length must be a multiple of 4 bytes and must not be less than 8 bytes
[INFO] Trace
Traceback (most recent call last):
  File "pkg/ierWorker.py", line 52, in process
  File "pkg/ierWorker.py", line 99, in _task_import
  File "pkg/api/device_lunii.py", line 789, in import_story
  File "pkg/api/device_lunii.py", line 1158, in import_story_v2
  File "pkg/api/device_lunii.py", line 281, in __v1v2_decipher
ValueError: Data length must be a multiple of 4 bytes and must not be less than 8 bytes
```

## Implementation Details

The code now checks if the chunk length is `>= 8` and a multiple of `4` before processing. If these conditions aren't met, the operation is skipped for that specific chunk.

It works now, but I’m not sure this is the proper fix.

Thank you for your hard work on this project! 