### PR TITLE
Fix Flam export crash on files with pre-1980 timestamps

### DIFF
--- a/pkg/api/device_flam.py
+++ b/pkg/api/device_flam.py
@@ -1515,7 +1515,16 @@ class FlamDevice(QtCore.QObject):
 
                     self.signal_story_progress.emit(one_story.short_uuid, index, len(story_flist))
                     self.signal_logger.emit(logging.DEBUG, story_arcnames[index])
-                    zip_out.write(file, story_arcnames[index])
+
+                    # ZIP format can't store timestamps before 1980, clamp them
+                    st = os.stat(file)
+                    date_time = time.localtime(st.st_mtime)[0:6]
+                    if date_time[0] < 1980:
+                        date_time = (1980, 1, 1, 0, 0, 0)
+                    zinfo = zipfile.ZipInfo(story_arcnames[index], date_time)
+                    zinfo.external_attr = (st.st_mode & 0xFFFF) << 16
+                    with open(file, 'rb') as src, zip_out.open(zinfo, 'w') as dst:
+                        shutil.copyfileobj(src, dst)
 
         except PermissionError as e:
             self.signal_logger.emit(logging.ERROR, QCoreApplication.translate("FlamDevice", "failed to create ZIP - {}").format(e))


### PR DESCRIPTION
## Problème

L'export d'une histoire depuis une Lunii **Flam** peut planter avec :

```
ValueError: ZIP does not support timestamps before 1980
```

Trace :

```
File "pkg/api/device_flam.py", line 1518, in export_backup_story
  zip_out.write(file, story_arcnames[index])
File ".../zipfile.py", line 391, in __init__
ValueError: ZIP does not support timestamps before 1980
```

Certains fichiers stockés sur la Flam ont une date de modification antérieure au 1ᵉʳ janvier 1980. Le format ZIP ne sait pas représenter ces dates, et `zipfile.ZipInfo.from_file` (appelé en interne par `ZipFile.write`) lève alors une `ValueError`, ce qui annule complètement l'export.

## Solution

Dans `export_backup_story`, au lieu de laisser `ZipFile.write` créer le `ZipInfo` via `from_file`, on construit le `ZipInfo` manuellement :

- on lit la `mtime` du fichier et on **clamp** toute date antérieure à 1980 sur `1980-01-01 00:00:00` ;
- on conserve les permissions du fichier (`external_attr`) ;
- on stream le contenu avec `shutil.copyfileobj` pour ne pas charger les fichiers entiers en mémoire.

Les fichiers concernés sont ainsi exportés avec une date plafonnée, sans interrompre l'export.

## Test

Build local (PyInstaller, PySide6 6.7.3 / Python 3.12) puis export de l'histoire « Totally Spies! » depuis une Flam : l'erreur ne se produit plus, le ZIP est généré correctement.