### PR TITLE
Fix FFmpeg/download SSL certificate verification on Windows (#64)

### DIFF
--- a/pkg/ierWorker.py
+++ b/pkg/ierWorker.py
@@ -13,6 +13,8 @@ import zipfile
 from PySide6 import QtCore
 from PySide6.QtCore import QObject, QThread
 import urllib
+import ssl
+import certifi
 
 from pkg.api import constants
 from pkg.api.constants import CFG_DIR, FFMPEG_BINARY, FLAM_V1, which_ffmpeg
@@ -30,6 +32,16 @@ ACTION_FACTORY = 8
 ACTION_DB_IMPORT = 9
 ACTION_DOWNLOAD = 11
 ACTION_FFMPEG = 12
+
+
+def _ssl_context():
+    # Use the certifi CA bundle for SSL verification. The stdlib ssl module
+    # does not read the Windows certificate store, which leads to
+    # CERTIFICATE_VERIFY_FAILED on some setups (see issue #64). The requests
+    # library used elsewhere already relies on certifi, so this keeps urlopen
+    # consistent with the rest of the app.
+    return ssl.create_default_context(cafile=certifi.where())
+
 
 class ierWorker(QObject):
     signal_total_progress = QtCore.Signal(int, int)
@@ -361,7 +373,7 @@ class ierWorker(QObject):
 
             block_size = 100 * 1024  # 100KB
             try:
-                with urllib.request.urlopen(src) as response, open(target, 'wb') as out_file:
+                with urllib.request.urlopen(src, context=_ssl_context()) as response, open(target, 'wb') as out_file:
                     total_size = int(response.getheader('Content-Length', 0))
                     downloaded = 0
                     while True:
@@ -409,7 +421,7 @@ class ierWorker(QObject):
 
         block_size = 100 * 1024  # 100KB
         try:
-            with urllib.request.urlopen(url) as response, open(archive_path, 'wb') as out_file:
+            with urllib.request.urlopen(url, context=_ssl_context()) as response, open(archive_path, 'wb') as out_file:
                 total_size = int(response.getheader('Content-Length', 0))
                 self.signal_message.emit(self.tr("Downloading {:,}MB".format(total_size)))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ psutil~=7.1.3
 py7zr~=0.22.0
 xxtea~=3.6.0
 requests~=2.32.5
+certifi
 pycryptodome==3.23.0
 pillow~=12.0.0
 mutagen~=1.47.0


### PR DESCRIPTION
@
## Problem

Downloading FFmpeg (and other files via `_task_download`) fails on some Windows setups with:

```
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)
```

Reported in #64.

## Cause

Both `urllib.request.urlopen` calls in `pkg/ierWorker.py` used the default SSL context. The stdlib `ssl` module does not read the Windows certificate store, so on machines without a usable CA bundle (fresh Python install, missing root certs) verification fails. The rest of the app uses `requests`, which bundles `certifi`, so those code paths are unaffected — which is why only the `urlopen`-based downloads break.

## Fix

Build an SSL context from the `certifi` CA bundle and pass it to both `urlopen` calls. This aligns `urlopen` with how `requests` already verifies certificates elsewhere in the app.

- `_ssl_context()` helper returns `ssl.create_default_context(cafile=certifi.where())`
- applied to the FFmpeg download and the generic file download
- `certifi` added explicitly to `requirements.txt` (already a transitive dependency of `requests`)

## Verification

Reproduced the exact error with an empty-CA SSL context, then confirmed the certifi-based context returns HTTP 200 against the same host.

Note: this fixes the common case (missing/empty CA store). It will not cover corporate proxy / AV TLS interception that injects a private root only into the OS store — that case would also break `requests` and needs `truststore`. The issue reports only the FFmpeg download failing, consistent with the missing-CA case.

Fixes #64
@