### PR TITLE
docs: document Flam USB connection mode prerequisite (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pour Windows 11 / MacOs (11 BigSur => 26 Tahoe) / Linux
 *  😎 **Flam support** 😎  
 L'application permet désormais d'importer les histoires Lunii sur votre Flam, sous réserve qu'elle soit en firmware v2.x.x  
     > **Attention :** la Flam est TRES lente en usb. Il faut etre patient. (environ 4min pour 80Mo)
+    > **Prérequis détection :** contrairement aux Lunii v1/v2 qui se montent automatiquement, la Flam doit être passée en **mode connexion USB** depuis ses paramètres (menu de l'appareil) pour exposer son stockage. Sans cela, elle ne fait que charger et n'apparaît ni dans l'explorateur ni dans Lunii.QT.
 
 * 😎 **Lunii v3 & Firmware 3.2.x** 😎  
 Lunii.QT a été mis à jour pour prendre en charge le dernier firmware (3.2.2 et suivants). Grâce à une analyse approfondie (j’aurais dû connecter les neurones et réfléchir 10 minutes de plus à la premère analyse), une solution **stable** et **TRÈS simple** a été trouvée.  
@@ -217,6 +218,8 @@ Lunii.QT vous offre la possibilité de sauvegarder la dernière version du Firmw
    
 
 ### Guide Pratique - Flam
+> **Prérequis :** activez le **mode connexion USB** dans les paramètres de la Flam avant toute opération. Un lecteur amovible doit apparaître dans l'explorateur de fichiers ; sinon Lunii.QT ne pourra pas détecter l'appareil.
+
 1. Récupération du firmware
    1. Sélectionnez votre Flam dans la liste des appareils
    2. Menu **Outils/Récupérer le firmware**

--- a/README_EN.md
+++ b/README_EN.md
@@ -16,6 +16,7 @@ for Windows 11 / MacOs (11 BigSur => 26 Tahoe) / Linux
 * 😎 **Flam support** 😎  
 The application now allows importing Lunii stories onto your Flam, provided it is running firmware v2.x.x.  
    > **Warning:** the Flam is VERY slow over USB. Please be patient. (around 4min for 80MB)
+   > **Detection prerequisite:** unlike the Lunii v1/v2 which mount automatically, the Flam must be switched to **USB connection mode** from its settings (on-device menu) to expose its storage. Otherwise it only charges and shows up neither in the file explorer nor in Lunii.QT.
 
 * 😎 **Lunii v3 & Firmware 3.2.x** 😎  
 Lunii.QT has been updated to support the latest firmware (3.2.2 and later). Thanks to a longer analysis (I should have spent 10 more minutes at the first sight to connect neurons), **a stable** and **VERY simple** workaround has been found.  
@@ -214,6 +215,8 @@ Lunii.QT allows you to backup the latest firmware version available from Lunii s
 
 
 ### HowTo - Flam
+> **Prerequisite:** enable **USB connection mode** in the Flam settings before any operation. A removable drive must appear in your file explorer; otherwise Lunii.QT cannot detect the device.
+
 1. Firmware retrieval  
    1. Select a Flam device
    2. Menu **Tools/Get FW** Update


### PR DESCRIPTION
## Context

Issue #67: a user reports that Lunii.QT does not detect their Flam (firmware v2.1.5), while loading stories on a Lunii works fine.

## Root cause

Not a code bug. Device detection (`find_devices` → `is_flam`, which looks for a `.mdf` file at the drive root) requires the Flam to be mounted as USB mass storage. Unlike the Lunii v1/v2, which auto-mount on connection, the Flam only exposes its storage when **USB connection mode** is enabled from the on-device settings. Otherwise it merely charges and appears neither in the OS file explorer nor in Lunii.QT.

## Change

Documentation only. Adds a prerequisite note about enabling USB connection mode to the Flam sections of both `README.md` (FR) and `README_EN.md` (EN):

- a "Detection prerequisite" line in the **Flam support** section
- a "Prerequisite" line at the top of the **HowTo - Flam** section

Refs #67
