### PR TITLE
Fix macOS releases failing to launch with py2app "Launch error"

### DIFF
--- a/.github/workflows/build_mac_arm.yml
+++ b/.github/workflows/build_mac_arm.yml
@@ -60,6 +60,41 @@ jobs:
         echo "SIZE POST-CLEANUP"
         du -sh ./dist/luniiQt*
 
+    # Two fixes that must run after the cleanup and before packaging:
+    #
+    # 1. py2app's launcher stub is a universal binary (x86_64 + arm64), but the
+    #    native extension modules pip installs on this runner are arm64-only
+    #    (PIL/_imaging, psutil, xxtea, pyppmd, ...). If LaunchServices picks the
+    #    x86_64 slice, the stub aborts inside __boot__.py with "incompatible
+    #    architecture" before the main script ever runs, and the user only sees
+    #    py2app's generic "Launch error" dialog. Thinning the stub leaves
+    #    LaunchServices no wrong slice to choose.
+    #    (Launching the binary directly from a shell always picked the native
+    #    slice, which is why this did not show up in a terminal.)
+    #
+    # 2. macos_cleanup.py deletes files that py2app had already sealed into the
+    #    code signature, so the shipped bundle failed `codesign --verify` with
+    #    "a sealed resource is missing or invalid". On Apple Silicon an invalid
+    #    signature is fatal and cannot be bypassed with "Open Anyway", so the
+    #    bundle has to be re-signed once it is final.
+    - name: Force native architecture and re-sign bundle
+      run: |
+        set -e
+        ARCH=arm64
+        APP=./dist/luniiQt.app
+        for exe in lunii-qt python; do
+          p="$APP/Contents/MacOS/$exe"
+          [ -e "$p" ] || continue
+          echo "$exe: $(lipo -archs "$p")"
+          if [ "$(lipo -archs "$p")" != "$ARCH" ]; then
+            lipo -thin "$ARCH" "$p" -output "$p.$ARCH"
+            mv "$p.$ARCH" "$p"
+            echo "$exe thinned to $(lipo -archs "$p")"
+          fi
+        done
+        codesign --force --deep --sign - "$APP"
+        codesign --verify --verbose=1 "$APP"
+
     # - name: Make Light portable archive
     #   run: |  
     #     cd dist

--- a/.github/workflows/build_mac_arm.yml
+++ b/.github/workflows/build_mac_arm.yml
@@ -24,6 +24,11 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
+        # Force the pure-Python charset_normalizer: the default wheel is mypyc-compiled
+        # and its extensions import a hash-named top-level module (e.g.
+        # ada92cb5d92a588d1b93__mypyc) that py2app does not collect, so the bundled
+        # package fails to import and requests falls back with a warning.
+        pip install --no-binary charset_normalizer --force-reinstall charset_normalizer
         pip install py2app
         brew install create-dmg
         
@@ -92,7 +97,16 @@ jobs:
             echo "$exe thinned to $(lipo -archs "$p")"
           fi
         done
-        codesign --force --deep --sign - "$APP"
+        # Sign nested code first, then the bundle. `--deep` is deprecated by Apple
+        # and refuses to sign a bundle containing an unsigned nested dylib, which
+        # happens depending on where a wheel's bundled libraries came from.
+        find "$APP/Contents" -type f \( -name '*.dylib' -o -name '*.so' \) | while read -r f; do
+          codesign --verify "$f" >/dev/null 2>&1 || codesign --force --sign - "$f"
+        done
+        if [ -e "$APP/Contents/MacOS/python" ]; then
+          codesign --force --sign - "$APP/Contents/MacOS/python"
+        fi
+        codesign --force --sign - "$APP"
         codesign --verify --verbose=1 "$APP"
 
     # - name: Make Light portable archive

--- a/.github/workflows/build_mac_intel.yml
+++ b/.github/workflows/build_mac_intel.yml
@@ -24,6 +24,11 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
+        # Force the pure-Python charset_normalizer: the default wheel is mypyc-compiled
+        # and its extensions import a hash-named top-level module (e.g.
+        # ada92cb5d92a588d1b93__mypyc) that py2app does not collect, so the bundled
+        # package fails to import and requests falls back with a warning.
+        pip install --no-binary charset_normalizer --force-reinstall charset_normalizer
         pip install py2app
         brew install create-dmg
         
@@ -90,7 +95,16 @@ jobs:
             echo "$exe thinned to $(lipo -archs "$p")"
           fi
         done
-        codesign --force --deep --sign - "$APP"
+        # Sign nested code first, then the bundle. `--deep` is deprecated by Apple
+        # and refuses to sign a bundle containing an unsigned nested dylib, which
+        # happens depending on where a wheel's bundled libraries came from.
+        find "$APP/Contents" -type f \( -name '*.dylib' -o -name '*.so' \) | while read -r f; do
+          codesign --verify "$f" >/dev/null 2>&1 || codesign --force --sign - "$f"
+        done
+        if [ -e "$APP/Contents/MacOS/python" ]; then
+          codesign --force --sign - "$APP/Contents/MacOS/python"
+        fi
+        codesign --force --sign - "$APP"
         codesign --verify --verbose=1 "$APP"
 
     # - name: Make Light portable archive

--- a/.github/workflows/build_mac_intel.yml
+++ b/.github/workflows/build_mac_intel.yml
@@ -60,6 +60,39 @@ jobs:
         echo "SIZE POST-CLEANUP"
         du -sh ./dist/luniiQt*
 
+    # Two fixes that must run after the cleanup and before packaging:
+    #
+    # 1. py2app's launcher stub is a universal binary (x86_64 + arm64), but the
+    #    native extension modules pip installs on this runner are x86_64-only.
+    #    On an Apple Silicon Mac, LaunchServices picks the stub's arm64 slice and
+    #    the stub then aborts inside __boot__.py with "incompatible architecture"
+    #    before the main script ever runs, showing only py2app's generic
+    #    "Launch error" dialog. Thinning the stub leaves no wrong slice to pick,
+    #    so this build runs consistently under Rosetta.
+    #
+    # 2. macos_cleanup.py deletes files that py2app had already sealed into the
+    #    code signature, so the shipped bundle failed `codesign --verify` with
+    #    "a sealed resource is missing or invalid". An invalid signature cannot
+    #    be bypassed with "Open Anyway", so the bundle has to be re-signed once
+    #    it is final.
+    - name: Force native architecture and re-sign bundle
+      run: |
+        set -e
+        ARCH=x86_64
+        APP=./dist/luniiQt.app
+        for exe in lunii-qt python; do
+          p="$APP/Contents/MacOS/$exe"
+          [ -e "$p" ] || continue
+          echo "$exe: $(lipo -archs "$p")"
+          if [ "$(lipo -archs "$p")" != "$ARCH" ]; then
+            lipo -thin "$ARCH" "$p" -output "$p.$ARCH"
+            mv "$p.$ARCH" "$p"
+            echo "$exe thinned to $(lipo -archs "$p")"
+          fi
+        done
+        codesign --force --deep --sign - "$APP"
+        codesign --verify --verbose=1 "$APP"
+
     # - name: Make Light portable archive
     #   run: |  
     #     cd dist

--- a/macos_setup.py
+++ b/macos_setup.py
@@ -20,7 +20,10 @@ OPTIONS = {
         'CFBundleDevelopmentRegion': 'English',
         'CFBundleDocumentTypes': [],
     },
-    'packages': ['PySide6', 'shiboken6'],
+    # charset_normalizer is imported lazily by requests, so py2app's dependency
+    # scan misses it and the bundle warns "Unable to find acceptable character
+    # detection dependency" at startup, degrading every requests call.
+    'packages': ['PySide6', 'shiboken6', 'charset_normalizer'],
     'excludes': ['tkinter', 'pytest', 'unittest', 'sqlite3'],
 }
 

--- a/macos_setup.py
+++ b/macos_setup.py
@@ -20,10 +20,15 @@ OPTIONS = {
         'CFBundleDevelopmentRegion': 'English',
         'CFBundleDocumentTypes': [],
     },
-    # charset_normalizer is imported lazily by requests, so py2app's dependency
-    # scan misses it and the bundle warns "Unable to find acceptable character
-    # detection dependency" at startup, degrading every requests call.
-    'packages': ['PySide6', 'shiboken6', 'charset_normalizer'],
+    # Copied wholesale rather than byte-compiled into the zip:
+    #  - charset_normalizer is imported lazily by requests, so py2app's dependency
+    #    scan misses it and every startup warns "Unable to find acceptable character
+    #    detection dependency". (The CI install also forces the pure-Python build --
+    #    the mypyc wheel needs a hash-named top-level module py2app cannot see.)
+    #  - backports is a namespace package, and setuptools vendors a backports.tarfile
+    #    whose __init__ shadows it in the zip. backports.zstd (py7zr -> pyzstd) then
+    #    goes missing and the app dies at startup on 'cannot import name zstd'.
+    'packages': ['PySide6', 'shiboken6', 'charset_normalizer', 'backports', 'pyzstd'],
     'excludes': ['tkinter', 'pytest', 'unittest', 'sqlite3'],
 }
 


### PR DESCRIPTION
The published macOS `.app` bundles cannot be launched from Finder — double-clicking gives py2app’s generic **"Launch error"** dialog with no traceback (and, before that, "damaged and can’t be opened" for some users).

I hit this with `luniiQt-v3.1.4-MacOs-arm64.dmg` on macOS 15 / Apple Silicon. There are **two independent defects**, both in the window between `macos_cleanup.py` and packaging.

## 1. Architecture mismatch → the "Launch error" dialog

py2app’s launcher stub is a **universal binary** (`x86_64 arm64`), but the native extension modules pip installs on the runner are **single-architecture**. In the arm64 build, 9 modules are arm64-only:

```
PIL/_imaging.so, PIL/_imagingmath.so, PIL/_imagingcms.so,
psutil/_psutil_osx.so, xxtea.so, backports/zstd/_zstd...so,
pyppmd/c/_ppmd.so, bcj/_bcj.so, inflate64/_inflate64.so
```

(the other 153 `.so` files *are* universal, so it is a mismatched bundle rather than a uniformly broken one)

When LaunchServices selects the stub’s **x86_64** slice, the first `dlopen` in `__boot__.py`’s PIL prescript fails. Captured via `open --stderr`:

```
ImportError: dlopen(.../lib-dynload/PIL/_imaging.so, 0x0002):
  (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64'))
```

The stub aborts **before `lunii-qt.py` runs**, which is why the dialog has no Python traceback to show. Running the binary directly from a shell always picked the native arm64 slice, so this does not reproduce in a terminal — only via Finder/LaunchServices.

`build_mac_intel.yml` has the mirror-image problem: its modules are x86_64-only, so on an Apple Silicon Mac LaunchServices picks the stub’s **arm64** slice and fails identically. Both workflows are fixed.

**Fix:** thin the stub to the build’s target architecture, so LaunchServices has no wrong slice to choose.

## 2. Invalid code signature → "damaged and can’t be opened"

`py2app` ad-hoc signs the bundle, sealing all ~2960 files. `macos_cleanup.py` then deletes most of PySide6, leaving the seal referencing files that no longer exist:

```
luniiQt.app: a sealed resource is missing or invalid
file missing: .../PySide6/Qt/qml/QtQuick/Controls/Imagine/StackView.qml
file missing: .../PySide6/Qt/lib/QtPrintSupport.framework/Resources/Info.plist
... (thousands more)
```

On Apple Silicon an invalid signature is fatal and — unlike *missing notarization* — **cannot** be bypassed with "Open Anyway", so the workaround documented in `README.md:401` does not help here.

**Fix:** re-sign ad-hoc after the cleanup, once the bundle is final.

## 3. Minor: missing `charset_normalizer`

`requests` imports it lazily, so py2app’s dependency scan misses it and the bundle warns at every startup:

```
RequestsDependencyWarning: Unable to find acceptable character detection dependency (chardet or charset_normalizer).
```

Added to the py2app `packages` list in `macos_setup.py`.

## Verification

Applied the new step to the shipped `v3.1.4` arm64 bundle:

| | before | after |
|---|---|---|
| `lipo -archs` (stub) | `x86_64 arm64` | `arm64` |
| `codesign --verify` | `a sealed resource is missing or invalid` | `valid on disk` |
| launch via LaunchServices | dies, "Launch error" | runs, stable, `LSArchitecture=arm64` |

## Note on notarization

This makes the bundle *launchable*, but the DMG/PKG are still unsigned and un-notarized (`spctl: rejected, source=no usable signature`), so first launch still needs right-click → Open. That gate **is** bypassable, unlike the broken signature above. Proper Developer ID signing + notarization would need Apple credentials in CI, so it is out of scope here — happy to follow up if you want it.