### PR TITLE
Fix story removal failing on macOS, and stop discarding error messages

### DIFF
--- a/pkg/api/device_flam.py
+++ b/pkg/api/device_flam.py
@@ -1,7 +1,6 @@
 from glob import glob
 import json
 import os.path
-import shutil
 import time
 import zipfile
 import binascii
@@ -20,6 +19,7 @@ from unidecode import unidecode
 
 from pkg.api import stories
 from pkg.api.aes_keys import reverse_bytes
+from pkg.api import fs_utils
 from pkg.api.constants import *
 from pkg.api.convert_audio import audio_to_mp3, mp3_tag_cleanup, tags_removal_required, transcoding_required
 from pkg.api.convert_image import image_to_bitmap_rle4, image_to_liff
@@ -288,11 +288,11 @@ class FlamDevice(QtCore.QObject):
 
                     # removing whole directory
                     self.signal_logger.emit(logging.INFO, QCoreApplication.translate("FlamDevice", "Deleting - {}").format(lost_story_path))
-                    shutil.rmtree(lost_story_path)
+                    fs_utils.rmtree(lost_story_path)
                     removed += 1
                 except (OSError, PermissionError) as e:
                     self.signal_logger.emit(logging.WARN, QCoreApplication.translate("FlamDevice", "Failed to delete - {}").format(lost_story_path))
-                    self.signal_logger.emit(logging.ERROR, e)
+                    self.signal_logger.emit(logging.ERROR, str(e))
 
         return removed, recovered_size//1024//1024
 
@@ -426,7 +426,7 @@ class FlamDevice(QtCore.QObject):
             with zipfile.ZipFile(file=story_path):
                 pass  # If opening succeeds, the archive is valid
         except zipfile.BadZipFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
 
         
@@ -442,7 +442,7 @@ class FlamDevice(QtCore.QObject):
             try:
                 new_uuid = UUID(bytes=zip_file.read(FILE_UUID))
             except ValueError as e:
-                self.signal_logger.emit(logging.ERROR, e)
+                self.signal_logger.emit(logging.ERROR, str(e))
                 return False
 
             # checking if UUID already loaded
@@ -533,7 +533,7 @@ class FlamDevice(QtCore.QObject):
             with zipfile.ZipFile(file=story_path):
                 pass  # If opening succeeds, the archive is valid
         except zipfile.BadZipFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
 
         # opening zip file
@@ -548,7 +548,7 @@ class FlamDevice(QtCore.QObject):
             try:
                 new_uuid = UUID(bytes=zip_file.read(FILE_UUID))
             except ValueError as e:
-                self.signal_logger.emit(logging.ERROR, e)
+                self.signal_logger.emit(logging.ERROR, str(e))
                 return False
 
             # checking if UUID already loaded
@@ -618,7 +618,7 @@ class FlamDevice(QtCore.QObject):
             with zipfile.ZipFile(file=story_path):
                 pass  # If opening succeeds, the archive is valid
         except zipfile.BadZipFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
 
         # opening zip file
@@ -725,7 +725,7 @@ class FlamDevice(QtCore.QObject):
             with py7zr.SevenZipFile(story_path, mode='r'):
                 pass  # If opening succeeds, the archive is valid
         except py7zr.exceptions.Bad7zFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
 
         # opening zip file
@@ -850,7 +850,7 @@ class FlamDevice(QtCore.QObject):
             with zipfile.ZipFile(file=story_path):
                 pass  # If opening succeeds, the archive is valid
         except zipfile.BadZipFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
         
         # opening zip file
@@ -926,7 +926,7 @@ class FlamDevice(QtCore.QObject):
             with zipfile.ZipFile(file=story_path):
                 pass  # If opening succeeds, the archive is valid
         except zipfile.BadZipFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
         
         # opening zip file
@@ -1034,7 +1034,7 @@ class FlamDevice(QtCore.QObject):
             with py7zr.SevenZipFile(story_path, mode='r'):
                 pass  # If opening succeeds, the archive is valid
         except py7zr.exceptions.Bad7zFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
 
         # opening zip file
@@ -1142,7 +1142,7 @@ class FlamDevice(QtCore.QObject):
             with zipfile.ZipFile(file=story_path):
                 pass  # If opening succeeds, the archive is valid
         except zipfile.BadZipFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
         
         # opening zip file
@@ -1160,7 +1160,7 @@ class FlamDevice(QtCore.QObject):
             try:
                 story_json = json.loads(zip_file.read(FILE_STUDIO_JSON))
             except ValueError as e:
-                self.signal_logger.emit(logging.ERROR, e)
+                self.signal_logger.emit(logging.ERROR, str(e))
                 return False
 
             studio_story = StudioStory(story_json)
@@ -1289,7 +1289,7 @@ class FlamDevice(QtCore.QObject):
             with py7zr.SevenZipFile(story_path, mode='r'):
                 pass  # If opening succeeds, the archive is valid
         except py7zr.exceptions.Bad7zFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
 
         # opening zip file
@@ -1307,7 +1307,7 @@ class FlamDevice(QtCore.QObject):
             try:
                 story_json = json.loads(zip_contents[FILE_STUDIO_JSON].read())
             except ValueError as e:
-                self.signal_logger.emit(logging.ERROR, e)
+                self.signal_logger.emit(logging.ERROR, str(e))
                 return False
 
             studio_story = StudioStory(story_json)
@@ -1732,14 +1732,14 @@ class FlamDevice(QtCore.QObject):
         hidden_story_dir = Path(self.mount_point).joinpath(f"{self.HIDDEN_STORIES_BASEDIR}{str(story_uuid)}")
         try:
             if os.path.isdir(story_dir):
-                shutil.rmtree(story_dir)
+                fs_utils.rmtree(story_dir)
             if os.path.isdir(hidden_story_dir):
-                shutil.rmtree(hidden_story_dir)
+                fs_utils.rmtree(hidden_story_dir)
         except OSError as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
         except PermissionError as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
         return True
 

--- a/pkg/api/device_lunii.py
+++ b/pkg/api/device_lunii.py
@@ -1,7 +1,6 @@
 import glob
 import json
 import os.path
-import shutil
 from string import hexdigits
 import time
 import zipfile
@@ -18,6 +17,7 @@ from PySide6 import QtCore
 from PySide6.QtCore import QCoreApplication
 
 from pkg.api.aes_keys import fetch_keys, reverse_bytes
+from pkg.api import fs_utils
 from pkg.api.constants import *
 from pkg.api import stories
 from pkg.api.convert_audio import audio_to_mp3, transcoding_required, tags_removal_required, mp3_tag_cleanup
@@ -579,11 +579,11 @@ class LuniiDevice(QtCore.QObject):
 
                     # removing whole directory
                     self.signal_logger.emit(logging.INFO, QCoreApplication.translate("LuniiDevice", "Deleting - {}").format(lost_story_path))
-                    shutil.rmtree(lost_story_path)
+                    fs_utils.rmtree(lost_story_path)
                     removed += 1
                 except (OSError, PermissionError) as e:
                     self.signal_logger.emit(logging.WARN, QCoreApplication.translate("LuniiDevice", "Failed to delete - {}").format(lost_story_path))
-                    self.signal_logger.emit(logging.ERROR, e)
+                    self.signal_logger.emit(logging.ERROR, str(e))
 
         return removed, recovered_size//1024//1024
 
@@ -752,7 +752,7 @@ class LuniiDevice(QtCore.QObject):
             with zipfile.ZipFile(file=story_path):
                 pass  # If opening succeeds, the archive is valid
         except zipfile.BadZipFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
         
         # opening zip file
@@ -767,7 +767,7 @@ class LuniiDevice(QtCore.QObject):
             try:
                 new_uuid = UUID(bytes=zip_file.read(FILE_UUID))
             except ValueError as e:
-                self.signal_logger.emit(logging.ERROR, e)
+                self.signal_logger.emit(logging.ERROR, str(e))
                 return False
         
             # checking if UUID already loaded
@@ -854,7 +854,7 @@ class LuniiDevice(QtCore.QObject):
             with zipfile.ZipFile(file=story_path):
                 pass  # If opening succeeds, the archive is valid
         except zipfile.BadZipFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
         
         # opening zip file
@@ -964,7 +964,7 @@ class LuniiDevice(QtCore.QObject):
             with py7zr.SevenZipFile(story_path, mode='r'):
                 pass  # If opening succeeds, the archive is valid
         except py7zr.exceptions.Bad7zFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
 
         # opening zip file
@@ -1079,7 +1079,7 @@ class LuniiDevice(QtCore.QObject):
             with zipfile.ZipFile(file=story_path):
                 pass  # If opening succeeds, the archive is valid
         except zipfile.BadZipFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
         
         # opening zip file
@@ -1154,7 +1154,7 @@ class LuniiDevice(QtCore.QObject):
             with zipfile.ZipFile(file=story_path):
                 pass  # If opening succeeds, the archive is valid
         except zipfile.BadZipFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
         
         # opening zip file
@@ -1172,7 +1172,7 @@ class LuniiDevice(QtCore.QObject):
             try:
                 story_json = json.loads(zip_file.read(FILE_STUDIO_JSON))
             except ValueError as e:
-                self.signal_logger.emit(logging.ERROR, e)
+                self.signal_logger.emit(logging.ERROR, str(e))
                 return False
 
             one_story = StudioStory(story_json)
@@ -1295,7 +1295,7 @@ class LuniiDevice(QtCore.QObject):
             with py7zr.SevenZipFile(story_path, mode='r'):
                 pass  # If opening succeeds, the archive is valid
         except py7zr.exceptions.Bad7zFile as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
 
         # opening zip file
@@ -1313,7 +1313,7 @@ class LuniiDevice(QtCore.QObject):
             try:
                 story_json = json.loads(zip_contents[FILE_STUDIO_JSON].read())
             except ValueError as e:
-                self.signal_logger.emit(logging.ERROR, e)
+                self.signal_logger.emit(logging.ERROR, str(e))
                 return False
 
             one_story = StudioStory(story_json)
@@ -1634,14 +1634,14 @@ class LuniiDevice(QtCore.QObject):
         hidden_story_dir = Path(self.mount_point).joinpath(f"{self.HIDDEN_STORIES_BASEDIR}{story_uuid.hex.upper()[-8:]}")
         try:
             if os.path.isdir(story_dir):
-                shutil.rmtree(story_dir)
+                fs_utils.rmtree(story_dir)
             if os.path.isdir(hidden_story_dir):
-                shutil.rmtree(hidden_story_dir)
+                fs_utils.rmtree(hidden_story_dir)
         except OSError as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
         except PermissionError as e:
-            self.signal_logger.emit(logging.ERROR, e)
+            self.signal_logger.emit(logging.ERROR, str(e))
             return False
         return True
 

--- a/pkg/api/fs_utils.py
+++ b/pkg/api/fs_utils.py
@@ -1,0 +1,44 @@
+import os
+import shutil
+import sys
+
+
+def _ignore_vanished(func, path, exc):
+    # A sidecar removed from under us is expected (see rmtree). Anything else --
+    # permissions, I/O errors -- must keep propagating so a failed delete is not
+    # mistaken for a successful one.
+    if not isinstance(exc, FileNotFoundError):
+        raise exc
+
+
+def rmtree(path):
+    """shutil.rmtree() that tolerates entries disappearing during the walk.
+
+    Lunii and Flam storage is FAT, which has no native extended attributes, so
+    macOS keeps them in AppleDouble sidecar files named "._<name>" beside each
+    entry. Deleting an entry also deletes its sidecar, but rmtree() enumerated
+    both up front, so it then tries to unlink a sidecar that is already gone:
+
+        FileNotFoundError: [Errno 2] No such file or directory: '._000'
+          File "shutil.py", line 672, in _rmtree_safe_fd
+
+    That aborted every story removal on macOS, reported as "Failed to remove".
+
+    The tree must exist: a missing path raises, so a wrong mount point cannot be
+    mistaken for a story that was successfully deleted.
+    """
+    os.lstat(path)  # raises FileNotFoundError / NotADirectoryError on a bad path
+    if sys.version_info >= (3, 12):
+        shutil.rmtree(path, onexc=_ignore_vanished)
+    else:
+        shutil.rmtree(
+            path,
+            onerror=lambda func, p, exc_info: _ignore_vanished(func, p, exc_info[1]),
+        )
+
+
+def rmtree_if_exists(path):
+    """Remove a directory tree when present. Returns True if it is gone afterwards."""
+    if os.path.isdir(path):
+        rmtree(path)
+    return not os.path.exists(path)


### PR DESCRIPTION
Removing any story on macOS always fails, and the reason is hidden. Two bugs that compound each other.

## 1. `shutil.rmtree()` dies on AppleDouble sidecars

Lunii/Flam storage is FAT, which has no native extended attributes, so macOS keeps them in AppleDouble sidecars named `._<name>` beside each entry. `shutil.rmtree()` enumerates a directory up front, then deletes entry by entry — but deleting an entry also removes its sidecar, so rmtree then tries to unlink one that is already gone:

```
FileNotFoundError: [Errno 2] No such file or directory: '._000'
  File "shutil.py", line 672, in _rmtree_safe_fd
```

Every story has `rf/000` and `sf/000`, each with a `._000` sidecar, so this fires on **every** removal. `remove_story()` reports `Failed to remove` and leaves the story on the device. The lost-story cleanup paths (`device_lunii.py:582`, `device_flam.py:291`) have the same problem.

**Fix** — a small `pkg/api/fs_utils.rmtree()` wrapper used at all six call sites. It ignores `FileNotFoundError` during the walk and nothing else:

- permission and I/O errors still propagate, so a failed delete is never reported as a success
- the tree must exist up front (`os.lstat`), so a wrong mount point cannot look like a story that was removed
- `onexc` on Python 3.12+, `onerror` below, since `onerror` is deprecated from 3.12

## 2. Exception objects on a `Signal(int, str)` render as an empty string

`signal_logger` is declared `Signal(int, str)` (`device_lunii.py:34`), but 28 handlers passed the exception itself:

```python
except OSError as e:
    self.signal_logger.emit(logging.ERROR, e)
```

PySide6 coerces that to `""`, so the user sees a bare `[ERROR]` line with no text — which is precisely what made bug 1 so hard to place. In the log it looked like:

```
[INFO]  🚧 Removing 653036E5 - Les transports...
[ERROR] 
[INFO]  🛑 Failed to remove : 'Les transports'
```

All 28 now pass `str(e)` — 12 in `device_lunii.py`, 16 in `device_flam.py`.

## Verification

On a real FAT32 volume with AppleDouble sidecars, under the **3.11 interpreter the macOS app bundles**:

| case | result |
|---|---|
| `shutil.rmtree()` on a story tree | `FileNotFoundError: ._IMG00001`, tree left behind |
| `fs_utils.rmtree()` on the same tree | removed, gone |
| missing path | still raises `FileNotFoundError` |
| read-only parent (APFS) | `PermissionError` still propagates |

And the coercion, measured rather than assumed:

```
emit(40, err)       -> ''
emit(40, str(err))  -> "[Errno 2] No such file or directory: '._000'"
```

## Notes

- `shutil` is no longer referenced in either device module, so the import was dropped.
- Not touched, but worth flagging: in both `__clean_up_story_dir()` the `except PermissionError` clause after `except OSError` is unreachable, since `PermissionError` subclasses `OSError`.
- Independent of #80 (the macOS launch fix) — this branches from `main` and touches different files, so the two can merge in either order.